### PR TITLE
JCN-191-logs-por-request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Logs for api requests
 
 ## [4.1.1] - 2019-10-01
 ### Changed

--- a/README.md
+++ b/README.md
@@ -78,22 +78,6 @@ Set response cookies. `cookies` must be an object with "key-value" cookies.
 * **setBody(body)**.
 Set the response body.
 
-* **shouldCreateLog(bool)**.
-Set if the api execution should be logged. `true` by default except for `get` http methods.
-
-* **shouldLogRequestData(bool)**.
-Set if the api request data should be logged. `true` by default.
-
-* **shouldLogRequestHeaders(bool)**.
-Set if the api response data should be logged. `true` by default.
-
-* **excludeFieldsLogRequestData(fields)**.
-Set the fields to exclude from the api request data that will be logged. `fields` should be an array.
-
-* **excludeFieldsLogResponseBody(fields)**.
-Set the fields to exclude from the api response body that will be logged. `fields` should be an array.
-
-
 ## Dispatcher
 
 This is the class you should use to dispatch your APIs. It takes the request data as constructor arguments and then finds you API file based on the endpoint and executes it.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ Returns the the headers of the request as a key-value object.
 * **cookies** (*getter*).
 Returns the the cookies of the request as a key-value object.
 
+* **shouldCreateLog(*getter*)**.
+Returns if the api execution should be logged as a boolean.
+
+* **shouldLogRequestData(*getter*)**.
+Returns if the api request data should be logged as a boolean.
+
+* **shouldLogRequestHeaders(*getter*)**.
+Returns if the api response data should be logged as a boolean.
+
+* **excludeFieldsLogRequestData(*getter*)**.
+Returns the fields to exclude from the api request data that will be logged as an array.
+
+* **excludeFieldsLogResponseBody(*getter*)**.
+Returns the fields to exclude from the api response body that will be logged as an array.
+
 ### Setters
 
 All this setters are chainable!
@@ -62,6 +77,21 @@ Set response cookies. `cookies` must be an object with "key-value" cookies.
 
 * **setBody(body)**.
 Set the response body.
+
+* **shouldCreateLog(bool)**.
+Set if the api execution should be logged. `true` by default except for `get` http methods.
+
+* **shouldLogRequestData(bool)**.
+Set if the api request data should be logged. `true` by default.
+
+* **shouldLogRequestHeaders(bool)**.
+Set if the api response data should be logged. `true` by default.
+
+* **excludeFieldsLogRequestData(fields)**.
+Set the fields to exclude from the api request data that will be logged. `fields` should be an array.
+
+* **excludeFieldsLogResponseBody(fields)**.
+Set the fields to exclude from the api response body that will be logged. `fields` should be an array.
 
 
 ## Dispatcher

--- a/lib/api.js
+++ b/lib/api.js
@@ -13,6 +13,40 @@ class API {
 		};
 	}
 
+	// Logging and setters and getters
+
+	set shouldCreateLog(bool) {
+		this._shouldCreateLog = bool;
+	}
+
+	get shouldCreateLog() {
+		return this._shouldCreateLog;
+	}
+
+	set shouldLogRequestData(bool) {
+		this._shouldLogRequestData = bool;
+	}
+
+	get shouldLogRequestData() {
+		return typeof this._shouldLogRequestData !== 'undefined' ? this._shouldLogRequestData : true;
+	}
+
+	set shouldLogRequestHeaders(bool) {
+		this._shouldLogRequestHeaders = bool;
+	}
+
+	get shouldLogRequestHeaders() {
+		return typeof this._shouldLogRequestHeaders !== 'undefined' ? this._shouldLogRequestHeaders : true;
+	}
+
+	set shouldLogResponseBody(bool) {
+		this._shouldLogResponseBody = bool;
+	}
+
+	get shouldLogResponseBody() {
+		return typeof this._shouldLogResponseBody !== 'undefined' ? this._shouldLogResponseBody : true;
+	}
+
 	// Request setters and getters
 
 	set data(data) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -13,54 +13,18 @@ class API {
 		};
 	}
 
-	// Logging and setters and getters
-
-	set shouldCreateLog(bool) {
-		this._shouldCreateLog = bool;
-	}
-
-	get shouldCreateLog() {
-		return this._shouldCreateLog;
-	}
-
-	set shouldLogRequestData(bool) {
-		this._shouldLogRequestData = bool;
-	}
+	// Setters and getters
 
 	get shouldLogRequestData() {
-		return typeof this._shouldLogRequestData !== 'undefined' ? this._shouldLogRequestData : true;
-	}
-
-	set shouldLogRequestHeaders(bool) {
-		this._shouldLogRequestHeaders = bool;
+		return true;
 	}
 
 	get shouldLogRequestHeaders() {
-		return typeof this._shouldLogRequestHeaders !== 'undefined' ? this._shouldLogRequestHeaders : true;
-	}
-
-	set shouldLogResponseBody(bool) {
-		this._shouldLogResponseBody = bool;
+		return true;
 	}
 
 	get shouldLogResponseBody() {
-		return typeof this._shouldLogResponseBody !== 'undefined' ? this._shouldLogResponseBody : true;
-	}
-
-	set excludeFieldsLogRequestData(fields) {
-		this._excludeFieldsLogRequestData = fields;
-	}
-
-	get excludeFieldsLogRequestData() {
-		return this._excludeFieldsLogRequestData;
-	}
-
-	set excludeFieldsLogResponseBody(fields) {
-		this._excludeFieldsLogResponseBody = fields;
-	}
-
-	get excludeFieldsLogResponseBody() {
-		return this._excludeFieldsLogResponseBody;
+		return true;
 	}
 
 	// Request setters and getters

--- a/lib/api.js
+++ b/lib/api.js
@@ -47,6 +47,22 @@ class API {
 		return typeof this._shouldLogResponseBody !== 'undefined' ? this._shouldLogResponseBody : true;
 	}
 
+	set excludeFieldsLogRequestData(fields) {
+		this._excludeFieldsLogRequestData = fields;
+	}
+
+	get excludeFieldsLogRequestData() {
+		return this._excludeFieldsLogRequestData;
+	}
+
+	set excludeFieldsLogResponseBody(fields) {
+		this._excludeFieldsLogResponseBody = fields;
+	}
+
+	get excludeFieldsLogResponseBody() {
+		return this._excludeFieldsLogResponseBody;
+	}
+
 	// Request setters and getters
 
 	set data(data) {

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -68,10 +68,10 @@ class Dispatcher {
 	_saveLog() {
 
 		// Set default in case of shouldCreateLog is not defined
-		if(typeof this.shouldCreateLog === 'undefined')
-			this.shouldCreateLog = this.endpoint !== 'get';
+		if(typeof this.api.shouldCreateLog === 'undefined')
+			this.api.shouldCreateLog = this.method !== 'get';
 
-		if(!this._isObject(this.session) || typeof this.session.clientCode !== 'string' || !this.shouldCreateLog)
+		if(!this._isObject(this.api.session) || typeof this.api.session.clientCode !== 'string' || !this.api.shouldCreateLog)
 			return;
 
 		const executionTime = this._executionFinished[1] / 1000000;
@@ -102,7 +102,7 @@ class Dispatcher {
 			executionTime
 		};
 
-		Log.add(this.session.clientCode, {
+		Log.add(this.api.session.clientCode, {
 			entity: 'api',
 			entityId,
 			type: 'api-request',

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -6,7 +6,7 @@ const { ApiSession } = require('@janiscommerce/api-session');
 const Log = require('@janiscommerce/log');
 
 const Fetcher = require('./fetcher');
-const { omitRecursive } = require('./utils');
+const { omitRecursive, isObject } = require('./utils');
 
 const API = require('./api');
 const APIError = require('./error');
@@ -26,23 +26,13 @@ class Dispatcher {
 	}
 
 	/**
-	 * Determines if object.
-	 *
-	 * @param {any} value The value
-	 * @return {boolean} True if object, False otherwise.
-	 */
-	_isObject(value) {
-		return typeof value === 'object' && !Array.isArray(value);
-	}
-
-	/**
 	 * Validates the request
 	 *
 	 * @param {any} request The request data
 	 */
 	_validateRequest(request) {
 
-		if(!this._isObject(request))
+		if(!isObject(request))
 			throw new APIError('request data must be an Object', APIError.codes.INVALID_REQUEST_DATA);
 
 		if(typeof request.endpoint !== 'string')
@@ -53,15 +43,15 @@ class Dispatcher {
 			throw new APIError('method must be an String', APIError.codes.INVALID_METHOD);
 
 		if(typeof request.headers !== 'undefined'
-			&& !this._isObject(request.headers))
+			&& !isObject(request.headers))
 			throw new APIError('headers must be an Object', APIError.codes.INVALID_HEADERS);
 
 		if(typeof request.cookies !== 'undefined'
-			&& !this._isObject(request.cookies))
+			&& !isObject(request.cookies))
 			throw new APIError('cookies must be an Object', APIError.codes.INVALID_COOKIES);
 
 		if(typeof request.authenticationData !== 'undefined'
-			&& !this._isObject(request.authenticationData))
+			&& !isObject(request.authenticationData))
 			throw new APIError('authenticationData must be an Object', APIError.codes.INVALID_AUTHENTICATION_DATA);
 	}
 
@@ -71,7 +61,7 @@ class Dispatcher {
 		if(typeof this.api.shouldCreateLog === 'undefined')
 			this.api.shouldCreateLog = this.method !== 'get';
 
-		return this._isObject(this.api.session) && typeof this.api.session.clientCode === 'string' && this.api.shouldCreateLog;
+		return isObject(this.api.session) && typeof this.api.session.clientCode === 'string' && this.api.shouldCreateLog;
 	}
 
 	_saveLog() {

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -3,7 +3,10 @@
 const { struct } = require('superstruct');
 const { ApiSession } = require('@janiscommerce/api-session');
 
+const Log = require('@janiscommerce/log');
+
 const Fetcher = require('./fetcher');
+const { omitRecursive } = require('./utils');
 
 const API = require('./api');
 const APIError = require('./error');
@@ -19,6 +22,7 @@ class Dispatcher {
 		this.headers = request.headers || {};
 		this.cookies = request.cookies || {};
 		this.authenticationData = request.authenticationData || {};
+		this._executionStarted = process.hrtime();
 	}
 
 	/**
@@ -61,6 +65,51 @@ class Dispatcher {
 			throw new APIError('authenticationData must be an Object', APIError.codes.INVALID_AUTHENTICATION_DATA);
 	}
 
+	_saveLog() {
+
+		// Set default in case of shouldCreateLog is not defined
+		if(typeof this.shouldCreateLog === 'undefined')
+			this.shouldCreateLog = this.endpoint !== 'get';
+
+		if(!this._isObject(this.session) || typeof this.session.clientCode !== 'string' || !this.shouldCreateLog)
+			return;
+
+		const executionTime = this._executionFinished[1] / 1000000;
+		const response = this.response();
+		const entityId = this.endpoint.split('/')[0];
+
+		const log = {
+			api: {
+				endpoint: this.endpoint,
+				httpMethod: this.method
+			},
+			request: {
+
+				...this.api.shouldLogRequestHeaders ?
+					{ headers: omitRecursive(this.headers, ['janis-api-key', 'janis-api-secret']) } : {},
+
+				...this.api.shouldLogRequestData ?
+					{ data: this.api.excludeFieldsLogRequestData ? omitRecursive(this.data, this.api.excludeFieldsLogRequestData) : this.data } : {}
+			},
+			response: {
+
+				code: response.code,
+				headers: response.headers,
+
+				...this.api.shouldLogResponseBody ?
+					{ body: this.api.excludeFieldsLogResponseBody ? omitRecursive(response.body, this.api.excludeFieldsLogResponseBody) : response.body } : {}
+			},
+			executionTime
+		};
+
+		Log.add(this.session.clientCode, {
+			entity: 'api',
+			entityId,
+			type: 'api-request',
+			log
+		});
+	}
+
 	get fetcher() {
 
 		if(!this._fetcher)
@@ -82,6 +131,10 @@ class Dispatcher {
 		await this.validate();
 
 		await this.process();
+
+		this._executionFinished = process.hrtime(this._executionStarted);
+
+		this._saveLog();
 
 		return this.response();
 	}

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -65,13 +65,18 @@ class Dispatcher {
 			throw new APIError('authenticationData must be an Object', APIError.codes.INVALID_AUTHENTICATION_DATA);
 	}
 
-	_saveLog() {
+	_shouldCreateLog() {
 
 		// Set default in case of shouldCreateLog is not defined
 		if(typeof this.api.shouldCreateLog === 'undefined')
 			this.api.shouldCreateLog = this.method !== 'get';
 
-		if(!this._isObject(this.api.session) || typeof this.api.session.clientCode !== 'string' || !this.api.shouldCreateLog)
+		return this._isObject(this.api.session) && typeof this.api.session.clientCode === 'string' && this.api.shouldCreateLog;
+	}
+
+	_saveLog() {
+
+		if(!this._shouldCreateLog())
 			return;
 
 		const executionTime = this._executionFinished[1] / 1000000;
@@ -83,24 +88,22 @@ class Dispatcher {
 				endpoint: this.endpoint,
 				httpMethod: this.method
 			},
-			request: {
-
-				...this.api.shouldLogRequestHeaders ?
-					{ headers: omitRecursive(this.headers, ['janis-api-key', 'janis-api-secret']) } : {},
-
-				...this.api.shouldLogRequestData ?
-					{ data: this.api.excludeFieldsLogRequestData ? omitRecursive(this.data, this.api.excludeFieldsLogRequestData) : this.data } : {}
-			},
+			request: {},
 			response: {
-
 				code: response.code,
-				headers: response.headers,
-
-				...this.api.shouldLogResponseBody ?
-					{ body: this.api.excludeFieldsLogResponseBody ? omitRecursive(response.body, this.api.excludeFieldsLogResponseBody) : response.body } : {}
+				headers: response.headers
 			},
 			executionTime
 		};
+
+		if(this.api.shouldLogRequestHeaders)
+			log.request.headers = omitRecursive(this.headers, ['janis-api-key', 'janis-api-secret']);
+
+		if(this.api.shouldLogRequestData)
+			log.request.data = omitRecursive(this.data, this.api.excludeFieldsLogRequestData);
+
+		if(this.api.shouldLogResponseBody)
+			log.response.body = omitRecursive(response.body, this.api.excludeFieldsLogResponseBody);
 
 		Log.add(this.api.session.clientCode, {
 			entity: 'api',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,17 @@ const omitRecursive = (object, exclude) => {
 	return omit(object, exclude);
 };
 
+/**
+	 * Determines if object.
+	 *
+	 * @param {any} value The value
+	 * @return {boolean} True if object, False otherwise.
+	 */
+const isObject = value => {
+	return typeof value === 'object' && !Array.isArray(value);
+};
+
 module.exports = {
-	omitRecursive
+	omitRecursive,
+	isObject
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const omit = require('lodash.omit');
+
+const omitRecursive = (object, exclude) => {
+
+	object = { ...object }; // Avoid original object modification
+
+	Object.entries(object).forEach(([key, value]) => {
+		object[key] = typeof value === 'object' && !Array.isArray(value) ? omitRecursive(value, exclude) : value;
+	});
+
+	return omit(object, exclude);
+};
+
+module.exports = {
+	omitRecursive
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,15 @@
         "md5": "^2.2.1"
       }
     },
+    "@janiscommerce/log": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/log/-/log-1.2.0.tgz",
+      "integrity": "sha512-u7yukvqGAScGsRYyKKifCdDEQbdlM2F9LRQakZjuuV1NjXE/ttMwLWzZDOAjAN4HxNaRMydkyFNI5E7USxtgPg==",
+      "requires": {
+        "aws-sdk": "^2.498.0",
+        "uuid": "^3.3.2"
+      }
+    },
     "@janiscommerce/model": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@janiscommerce/model/-/model-3.0.0.tgz",
@@ -144,18 +153,18 @@
       "integrity": "sha512-BzB+m4+WYGhHepRxysW9i0Ndq6/5pAZEnPjHBM1BcgQ0WXUwhjyzPu3+lDJv9V9eUeaUNA4XcOTxYGNW78xBig=="
     },
     "@sinonjs/commons": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
-      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
-      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
@@ -163,14 +172,14 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
-      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.3.0",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
       }
     },
     "@sinonjs/text-encoding": {
@@ -276,11 +285,32 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.566.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.566.0.tgz",
+      "integrity": "sha512-AifnTGUUOri1xaOK7UyE4Qol97Cr309SJxA0EKuGBUkCG7KehgPYTMm13JAuXU0lyn7y0X6o1RKvNYeYsZ5DCg==",
+      "requires": {
+        "buffer": "^4.9.1",
+        "events": "^1.1.1",
+        "ieee754": "^1.1.13",
+        "jmespath": "^0.15.0",
+        "querystring": "^0.2.0",
+        "sax": "^1.2.1",
+        "url": "^0.10.3",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -297,6 +327,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "caching-transform": {
       "version": "3.0.2",
@@ -602,7 +642,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -650,7 +689,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -664,7 +702,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -910,6 +947,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -1107,8 +1149,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1193,7 +1234,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1207,8 +1247,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "hasha": {
       "version": "3.0.0",
@@ -1372,6 +1411,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1456,8 +1500,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -1471,8 +1514,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-directory": {
       "version": "0.3.1",
@@ -1509,7 +1551,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -1524,7 +1565,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -1532,8 +1572,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1635,6 +1674,11 @@
       "requires": {
         "handlebars": "^4.1.2"
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1742,10 +1786,15 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
     "lolex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
-      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "lru-cache": {
@@ -1955,12 +2004,12 @@
       "dev": true
     },
     "nise": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
-      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/formatio": "^3.2.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
@@ -2078,8 +2127,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -2103,6 +2151,15 @@
         "es-abstract": "^1.12.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.values": {
@@ -2353,6 +2410,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -2477,6 +2539,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -2534,17 +2601,17 @@
       "dev": true
     },
     "sinon": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
-      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.4.0",
         "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.1",
+        "@sinonjs/samsam": "^3.3.3",
         "diff": "^3.5.0",
-        "lolex": "^4.0.1",
-        "nise": "^1.4.10",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
         "supports-color": "^5.5.0"
       }
     },
@@ -2931,11 +2998,35 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -3026,6 +3117,21 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
+    },
+    "xml2js": {
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+      "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "util.promisify": "~1.0.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "mocha": "^5.2.0",
     "mock-require": "^3.0.3",
     "nyc": "^14.1.1",
-    "sinon": "^7.3.2"
+    "sinon": "^7.5.0"
   },
   "dependencies": {
     "@janiscommerce/api-session": "^1.2.0",
+    "@janiscommerce/log": "^1.2.0",
+    "lodash.omit": "^4.5.0",
     "superstruct": "^0.6.1"
   }
 }

--- a/tests/dispatcher-test.js
+++ b/tests/dispatcher-test.js
@@ -4,6 +4,9 @@ const path = require('path');
 const mockRequire = require('mock-require');
 
 const assert = require('assert');
+const sandbox = require('sinon').createSandbox();
+
+const Log = require('@janiscommerce/log');
 
 const { API, APIError, Dispatcher } = require('../lib');
 const Fetcher = require('../lib/fetcher');
@@ -139,11 +142,13 @@ describe('Dispatcher', function() {
 		mock('validate-correctly-endpoint/list', ValidateOk);
 		mock('valid-endpoint/list', ValidProcess);
 		mock('valid-endpoint/get', ValidProcess);
+		sandbox.stub(Log, 'add');
 	});
 
 	afterEach(() => {
 		delete process.env.MS_PATH;
 		mockRequire.stopAll();
+		sandbox.restore();
 	});
 
 	const test = async (myApiData, code, headers = {}, cookies = {}) => {


### PR DESCRIPTION
**JCN-191-LOGS-POR-REQUEST**
JCN-191 Guardar logs por cada api request

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-191

**DESCRIPCIÓN DEL REQUERIMIENTO**
**1.1.** Modificar el package janis-commerce/api para guardar logs en cada request, utilizando el package @janiscommerce/log
**1.2.** Se debe guardar un log cuando las API sean de cliente, detectando this.session.clientCode
**1.3.** Guardar el log luego de generar la respuesta
**1.4.** Se debe poder configurar en cada apis (con getters en la clase api)
**1.4.1.** Método shouldCreateLog para determinar si la api debe crear logs o no. Default true para todos los httpMethod menos GET, Default false para httpMethod GET.
**1.4.2.** Método shouldLogRequestData para determinar si se guarda la data recibida (qs o data). Default true.
**1.4.3.** Método shouldLogRequestHeaders para determinar si se guardan los headers de la request. Default true.
- Se deben excluir SIEMPRE en caso de llegar los headers janis-api-key y janis-api-secret

**1.4.4.** Método shouldLogResponseBody para determinar si se guarda el body de respuesta. Default true.
**1.4.5.** Método excludeFieldsLogRequestData. Este getter debe devolver un array de strings de campos que se deben excluir de la data de request. Esto se hace para no exponer datos sensibles.
**1.4.6.** Método excludeFieldsLogResponseBody. Este getter debe devolver un array de strings de campos que se deben excluir del body de respusta. Esto se hace para no exponer datos sensibles.
**1.5.1.** El dato entityName se debe leer del endpoint. Ej. /api/product sería ‘product’, /api/client/2 sería ‘client’
**1.5.2.** El dato executionTime se debe empezar a calcular y enviar. Se debe iniciar la marca de tiempo al construir la clase Dispatch y luego del método process() se debe calcular la diferencia.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados