### PR TITLE
JCN-fix-async-log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Logs for api request not awaited causing some logs not to be successfully sent
+
 ## [4.2.3] - 2020-04-03
 ### Changed
 - Dependencies updated

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -95,7 +95,7 @@ class Dispatcher {
 		if(this.api.shouldLogResponseBody)
 			log.response.body = omitRecursive(response.body, this.api.excludeFieldsLogResponseBody);
 
-		Log.add(this.api.session.clientCode, {
+		return Log.add(this.api.session.clientCode, {
 			entity: 'api',
 			entityId,
 			type: 'api-request',
@@ -127,7 +127,7 @@ class Dispatcher {
 
 		this._executionFinished = process.hrtime(this._executionStarted);
 
-		this._saveLog();
+		await this._saveLog();
 
 		return this.response();
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/api",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/dispatcher-test.js
+++ b/tests/dispatcher-test.js
@@ -178,7 +178,7 @@ describe('Dispatcher', function() {
 		mock('logs-disabled/get', LogsDisabled);
 		mock('logs-minimal/list', LogsMinimal);
 		mock('logs-minimal/get', LogsMinimal);
-		sandbox.stub(Log, 'add');
+		sandbox.stub(Log, 'add').resolves();
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
**DESCRIPCIÓN DEL REQUERIMIENTO**
- Agregarle `await` al metodo `Log.add` para que dejen de perderse logs cuando la ejecución termina antes de que el log pueda enviarse correctamente.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agrego el await al envio de logs